### PR TITLE
[#157032509] Set the Subject Key Identifier when generating certificates

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -486,6 +486,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b4ce68f24eef1c2053f490a4ea8305b55714da34bc96af60215a0dd5d75a745f"
+  inputs-digest = "9b2e10085404ca4cef989e5fca1de9d654465dc80343e2b26e8f39e18269f9dc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -155,8 +155,8 @@
     "types",
     "types/typesfakes"
   ]
-  revision = "d29aa99b7c301778efea4714252b6ef549089d6b"
-  version = "v0.0.124"
+  revision = "641103772a0c5966f54db31d39a54d0e35c5ae7c"
+  source = "github.com/alphagov/paas-config-server"
 
 [[projects]]
   branch = "master"
@@ -486,6 +486,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9b2e10085404ca4cef989e5fca1de9d654465dc80343e2b26e8f39e18269f9dc"
+  inputs-digest = "1795c02293cbee7ce4e4e0ddfc85599de2fd5754f5ec5421642b95a7e1e3cf4b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -15,8 +15,8 @@ required = ["github.com/onsi/ginkgo/ginkgo", "github.com/maxbrunsfeld/counterfei
   name = "github.com/cloudfoundry/bosh-utils"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/cloudfoundry/bosh-davcli"
+  version = "v0.0.26"
 
 [[constraint]]
   name = "github.com/cloudfoundry/bosh-s3cli"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,3 +29,8 @@ required = ["github.com/onsi/ginkgo/ginkgo", "github.com/maxbrunsfeld/counterfei
 [[constraint]]
   name = "github.com/vito/go-interact"
   revision = "fa338ed9e9ecbb0e9c2e6c7a0160d9fc9b0efbd9"
+
+[[constraint]]
+  name = "github.com/cloudfoundry/config-server"
+  source = "github.com/alphagov/paas-config-server"
+  revision = "641103772a0c5966f54db31d39a54d0e35c5ae7c"

--- a/vendor/github.com/cloudfoundry/config-server/types/certificate_generator.go
+++ b/vendor/github.com/cloudfoundry/config-server/types/certificate_generator.go
@@ -1,10 +1,13 @@
 package types
 
 import (
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha1"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"math/big"
 	"net"
@@ -84,6 +87,10 @@ func (cfg CertificateGenerator) generateCertificate(cParams certParams) (CertRes
 
 	if cParams.IsCA {
 		certTemplate.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+		certTemplate.SubjectKeyId, err = generateSubjectKeyID(&privateKey.PublicKey)
+		if err != nil {
+			return certResponse, errors.WrapError(err, "Generating Subject Key ID")
+		}
 
 		signingKey := privateKey
 		signingCA := &certTemplate
@@ -104,6 +111,10 @@ func (cfg CertificateGenerator) generateCertificate(cParams certParams) (CertRes
 			return certResponse, errors.Error("Missing required CA name")
 		}
 		certTemplate.KeyUsage = x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature
+		certTemplate.SubjectKeyId, err = generateSubjectKeyID(&privateKey.PublicKey)
+		if err != nil {
+			return certResponse, errors.WrapError(err, "Generating Subject Key ID")
+		}
 
 		extKeyUsages := certTemplate.ExtKeyUsage
 		if len(cParams.ExtKeyUsage) != 0 {
@@ -214,4 +225,20 @@ func objToStruct(input interface{}, str interface{}) error {
 	}
 
 	return nil
+}
+
+// GenerateSubjectKeyID generates a Subject Key Identifier for a certificate
+// The identifier is the 160-bit SHA-1 hash of the public key
+func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		pubBytes, err := asn1.Marshal(*pub)
+		if err != nil {
+			return nil, err
+		}
+		hash := sha1.Sum(pubBytes)
+		return hash[:], nil
+	default:
+		return nil, errors.Error("only RSA public key is supported")
+	}
 }


### PR DESCRIPTION
## What

Update the config-server library to set the Subject Key Identifier when generating certificates. (https://github.com/alphagov/paas-config-server/pull/2)

BOSH cli can be used to generate certificates into a variable store - based on the manifest variable definitons.
There is a known issue if you try to rotate the CA certificates outlined in [1].

The root of the problem is that when OpenSSL is configured to trust multiple CAs, and two of them have the same subject name, OpenSSL will only verify certificates against the first one (see [2] in OpenSSL code).

One solution for the CA certificate rotation problem is to set the Subject Key Identifiers so OpenSSL will be able to handle multiple certificates with the same subject name.

[1] https://docs.google.com/document/d/1vKxziTEvIgKHubukoyAGaJzGqrMBjun7JffbunlLBPg/edit#heading=h.wftyivqbaag4
[2] https://github.com/openssl/openssl/blob/49f6cb968ff63793f6671d9026fb2a7034dad79a/crypto/x509/x509_lu.c#L613-L617

## How to review

Code review

## How to merge

❗️ The WIP commit needs to be updated with the final config-server-build

### Build the binary

```
mkdir out
docker run -it --rm -e GOOS=linux -e GOARCH=amd64 -e CGO_ENABLED=0 -e FILENAME_PREFIX="" -v `pwd`:/go/gopath/src/github.com/cloudfoundry/bosh-cli -v `pwd`/out:/go/compiled-linux golang:1.7.1 bash
mkdir version-semver && echo "3.0.1-ski" > version-semver/number
gopath/src/github.com/cloudfoundry/bosh-cli/ci/tasks/build.sh
exit
```

The binary will be in the out directory.

Create a release in this repository and upload the final binary. Put the SHA1 hash of the binary in the release comments.

## Who can review it

Not me.